### PR TITLE
Add title to prompt listings in README

### DIFF
--- a/.github/scripts/update_views.py
+++ b/.github/scripts/update_views.py
@@ -38,11 +38,11 @@ def update_views():
                     
                     categories[formatted_category].append({
                         'name': prompt_dir,
+                        'title': metadata['title'],
                         'description': metadata['one_line_description'],
                         'path': f'prompts/{category}/{prompt_dir}/view.md'
                     })
 
-    # Update README
     readme_content = readme_template.render(categories=categories)
     with open('README.md', 'w') as f:
         f.write(readme_content)

--- a/.github/templates/readme_template.md
+++ b/.github/templates/readme_template.md
@@ -10,7 +10,7 @@ Welcome to my **Prompt Library**. This repository contains a collection of promp
 
 {% for prompt in prompts %}
 
-- [{{ prompt.description }}]({{ prompt.path }})
+- [{{ prompt.title }}]({{ prompt.path }}) - {{prompt.description}}
 {% endfor %}
 
 {% endfor %}

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Welcome to my **Prompt Library**. This repository contains a collection of promp
 
 
 
-- [Analyzes AI prompts and generates structured outputs with metadata and formatting](prompts/prompt_engineering/ai_prompt_analyzer_and_output_generator/view.md)
+- [AI Prompt Analyzer and Output Generator](prompts/prompt_engineering/ai_prompt_analyzer_and_output_generator/view.md) - Analyzes AI prompts and generates structured outputs with metadata and formatting
 
 
 
@@ -19,9 +19,9 @@ Welcome to my **Prompt Library**. This repository contains a collection of promp
 
 
 
-- [Generates concise, informative git commit messages with emojis following Conventional Commits](prompts/software_engineering/git_commit_message_writer_with_emojis/view.md)
+- [Git Commit Message Writer](prompts/software_engineering/git_commit_message_writer_with_emojis/view.md) - Generates concise, informative git commit messages with emojis following Conventional Commits
 
 
-- [Creates comprehensive software specifications based on user requirements](prompts/software_engineering/software_specification_generator/view.md)
+- [Software Specification Generator](prompts/software_engineering/software_specification_generator/view.md) - Creates comprehensive software specifications based on user requirements
 
 


### PR DESCRIPTION
## Description
This PR enhances the README.md file by including the title of each prompt in the listing, providing more context and improving the overall user experience when browsing the Prompt Library.

## Changes
- Updated `.github/scripts/update_views.py` to include the 'title' field from the metadata when generating prompt listings
- Modified `.github/templates/readme_template.md` to display both the title and description for each prompt

## Impact
- Improves readability and discoverability of prompts in the README
- Provides users with more information at a glance without needing to click through to individual prompt pages

## Testing
- Visually inspected the generated README to ensure proper formatting and display of titles and descriptions